### PR TITLE
Prevent errors when panel has no className

### DIFF
--- a/lib/atom-keyboard-macros-vim.coffee
+++ b/lib/atom-keyboard-macros-vim.coffee
@@ -99,7 +99,7 @@ module.exports = AtomKeyboardMacrosVim =
     inputPanel = null
     for panel in panels
       className = panel.className or panel.item.className
-      if className.indexOf('normal-mode-input') == 0
+      if className and className.indexOf('normal-mode-input') == 0
         inputPanel = panel
         break
 


### PR DESCRIPTION
Not all panels have a `className`, resulting in an `indexOf` error. This resolves #5.
