### PR TITLE
Add vim-mode-plus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atom-keyboard-macros-vim package
 
-Keyboard macro extension for Atom vim-mode.
+Keyboard macro extension for Atom vim-mode and vim-mode-plus.
 
 # Shortcuts
 

--- a/keymaps/atom-keyboard-macros-vim.cson
+++ b/keymaps/atom-keyboard-macros-vim.cson
@@ -11,3 +11,7 @@
 'atom-text-editor.vim-mode:not(.insert-mode)':
   'q': 'atom-keyboard-macros-vim:toggle_record_macro_vim'
   '@': 'atom-keyboard-macros-vim:execute_macro_vim'
+
+'atom-text-editor.vim-mode-plus:not(.insert-mode)':
+  'q': 'atom-keyboard-macros-vim:toggle_record_macro_vim'
+  '@': 'atom-keyboard-macros-vim:execute_macro_vim'


### PR DESCRIPTION
Implemented https://github.com/JunSuzukiJapan/atom-keyboard-macros-vim/issues/5#issuecomment-212846780 so it just works for anyone installing this alongside either vim-mode or vim-mode-plus!
