### PR TITLE
Support @@ to call the last macro

### DIFF
--- a/lib/atom-keyboard-macros-vim.coffee
+++ b/lib/atom-keyboard-macros-vim.coffee
@@ -237,7 +237,10 @@ module.exports = AtomKeyboardMacrosVim =
     #console.log('vim_module', @vim_module)
     editor = atom.views.getView(atom.workspace.getActiveTextEditor())
     editor.focus()
-    AtomKeyboardMacros.execute_named_macro_with_string(name)
+    if name == "@"
+      AtomKeyboardMacros.call_last_kbd_macro()
+    else
+      AtomKeyboardMacros.execute_named_macro_with_string(name)
 
 class Input
   constructor: (@characters) ->


### PR DESCRIPTION
Simply call `AtomKeyboardMacros.call_last_kbd_macro()` if the 'name' of the macro selected is `@` to support the `@@` functionality of vim.
